### PR TITLE
Details:

### DIFF
--- a/doc/samples/tasks/support/instance_dd_test.sh
+++ b/doc/samples/tasks/support/instance_dd_test.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+sudo resize2fs /dev/vda1 1>/dev/null 2>&1
 time_seconds(){ (time -p $1 ) 2>&1 |awk '/real/{print $2}'; }
 file=/tmp/test.img
 c=1000 #1GB


### PR DESCRIPTION
When using cirros images, of any flavor, e.g. tiny,
the root filesystem in the image is far smaller than
the flavor creates.  As such, the dd write silently fails
and the time results are incorrectly brief.  The resize2fs
corrects the root volume size and we get more accurate results.
