### PR TITLE
Bug in getting network subnet

### DIFF
--- a/rally/verification/verifiers/tempest/config.py
+++ b/rally/verification/verifiers/tempest/config.py
@@ -213,7 +213,7 @@ class TempestConf(object):
                     # TODO(akurilin): create public subnet
                     LOG.warn('No public subnet is found.')
             else:
-                subnets = neutron.list_subnets()
+                subnets = neutron.list_subnets()['subnets']
                 if subnets:
                     subnet = subnets[0]
                 else:


### PR DESCRIPTION
It will run into exception of 'KeyError': 0, because it should get 'subnets' first from the dictionary.
Signed-off-by: Jiantao He hejiantao5@gmail.com
