### PR TITLE
fix tempest.conf autogenerated file 

### DIFF
--- a/rally/deploy/engines/existing.py
+++ b/rally/deploy/engines/existing.py
@@ -126,6 +126,7 @@ class ExistingCloud(engine.EngineFactory):
             endpoint=common.get("endpoint"),
             domain_name=user.get("domain_name"),
             user_domain_name=user.get("user_domain_name", "Default"),
+            admin_domain_name=user.get("admin_domain_name", "Default"),
             project_domain_name=user.get("project_domain_name", "Default"),
             https_insecure=common.get("https_insecure", False),
             https_cacert=common.get("https_cacert")

--- a/rally/objects/endpoint.py
+++ b/rally/objects/endpoint.py
@@ -22,7 +22,7 @@ class Endpoint(object):
                  permission=consts.EndpointPermission.USER,
                  region_name=None, endpoint_type=consts.EndpointType.PUBLIC,
                  admin_port=None, domain_name=None, endpoint=None,
-                 user_domain_name="Default", project_domain_name="Default",
+                 user_domain_name="Default", admin_domain_name="Default", project_domain_name="Default",
                  https_insecure=None, https_cacert=None):
         self.auth_url = auth_url
         self.username = username
@@ -33,6 +33,7 @@ class Endpoint(object):
         self.endpoint_type = endpoint_type
         self.domain_name = domain_name
         self.user_domain_name = user_domain_name
+        self.admin_domain_name = admin_domain_name
         self.project_domain_name = project_domain_name
         self.endpoint = endpoint
         self.insecure = https_insecure
@@ -52,6 +53,7 @@ class Endpoint(object):
                "https_insecure": self.insecure,
                "https_cacert": self.cacert,
                "user_domain_name": self.user_domain_name,
+               "admin_domain_name": self.admin_domain_name,
                "project_domain_name": self.project_domain_name}
         if include_permission:
             dct["permission"] = self.permission

--- a/rally/verification/tempest/config.py
+++ b/rally/verification/tempest/config.py
@@ -200,6 +200,8 @@ class TempestConf(object):
         self.conf.set(section_name, "uri", self.endpoint["auth_url"])
         self.conf.set(section_name, "uri_v3",
                       self.endpoint["auth_url"].replace("/v2.0", "/v3"))
+        self.conf.set(section_name, "admin_domain_name",
+                      self.endpoint["admin_domain_name"])
 
     def _set_network(self, section_name="network"):
         if "neutron" in self.available_services:

--- a/samples/deployments/existing-keystone-v3.json
+++ b/samples/deployments/existing-keystone-v3.json
@@ -7,6 +7,7 @@
         "username": "admin",
         "password": "myadminpass",
         "user_domain_name": "admin",
+        "admin_domain_name": "default",
         "project_name": "admin",
         "project_domain_name": "admin",
     },

--- a/tests/unit/deploy/engines/test_existing.py
+++ b/tests/unit/deploy/engines/test_existing.py
@@ -41,6 +41,7 @@ class TestExistingCloud(test.TestCase):
                     "domain_name": None,
                     "project_domain_name": "Default",
                     "user_domain_name": "Default",
+                    "admin_domain_name": "Default",
                 }
             }
         }

--- a/tests/unit/objects/test_endpoint.py
+++ b/tests/unit/objects/test_endpoint.py
@@ -36,7 +36,8 @@ class EndpointTestCase(test.TestCase):
                           "https_insecure": None,
                           "https_cacert": None,
                           "project_domain_name": "Default",
-                          "user_domain_name": "Default"})
+                          "user_domain_name": "Default",
+                          "admin_domain_name": "Default"})
 
     def test_to_dict_with_include_permission(self):
         endpoint = objects.Endpoint("foo_url", "foo_user", "foo_password",
@@ -55,7 +56,8 @@ class EndpointTestCase(test.TestCase):
                           "https_insecure": None,
                           "https_cacert": None,
                           "project_domain_name": "Default",
-                          "user_domain_name": "Default"})
+                          "user_domain_name": "Default",
+                          "admin_domain_name": "Default"})
 
     def test_to_dict_with_kwarg_endpoint(self):
         endpoint = objects.Endpoint("foo_url", "foo_user", "foo_password",
@@ -74,4 +76,5 @@ class EndpointTestCase(test.TestCase):
                           "https_insecure": None,
                           "https_cacert": None,
                           "project_domain_name": "Default",
-                          "user_domain_name": "Default"})
+                          "user_domain_name": "Default",
+                          "admin_domain_name": "Default"})

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -37,7 +37,8 @@ FAKE_DEPLOYMENT_CONFIG = {
         "tenant_name": "demo",
         "domain_name": None,
         "project_domain_name": "Default",
-        "user_domain_name": "Default"
+        "user_domain_name": "Default",
+        "admin_domain_name": "Default"
     },
     "region_name": "RegionOne",
     "endpoint_type": consts.EndpointType.INTERNAL,

--- a/tests/unit/verification/test_config.py
+++ b/tests/unit/verification/test_config.py
@@ -41,7 +41,8 @@ class ConfigTestCase(test.TestCase):
                          "tenant_name": "test",
                          "password": "test",
                          "auth_url": "http://test/v2.0",
-                         "permission": "admin"}
+                         "permission": "admin",
+                         "admin_domain_name": "Default"}
         mock_get.return_value = {"admin": self.endpoint}
         self.deployment = "fake_deployment"
         self.conf_generator = config.TempestConf(self.deployment)
@@ -241,9 +242,11 @@ class ConfigTestCase(test.TestCase):
                     ("admin_username", self.endpoint["username"]),
                     ("admin_password", self.endpoint["password"]),
                     ("admin_tenant_name", self.endpoint["username"]),
+                    ("admin_domain_name", self.endpoint["admin_domain_name"]),
                     ("uri", self.endpoint["auth_url"]),
                     ("uri_v3", self.endpoint["auth_url"].replace("/v2.0",
                                                                  "/v3")))
+
         results = self._remove_default_section(
             self.conf_generator.conf.items("identity"))
         self.assertEqual(sorted(expected), sorted(results))


### PR DESCRIPTION
by adding a line admin_domain_name=default in identity section of tempest.conf 
without this line, all the keystone v3 tests from Tempest are seen as failed. 
With this line they are successfull