### PR TITLE
New ping test sample and restricted the sec rules created by Rally.

### DIFF
--- a/rally/plugins/openstack/context/secgroup.py
+++ b/rally/plugins/openstack/context/secgroup.py
@@ -29,10 +29,10 @@ SSH_GROUP_NAME = "rally_ssh_open"
 
 
 def _prepare_open_secgroup(endpoint, secgroup_name):
-    """Generate secgroup allowing all tcp/udp/icmp access.
+    """Generate secgroup allowing SSH access and ICMP.
 
     In order to run tests on instances it is necessary to have SSH access.
-    This function generates a secgroup which allows all tcp/udp/icmp access.
+    This function generates a secgroup which allows SSH access as well as ICMP.
 
     :param endpoint: clients endpoint
     :param secgroup_name: security group name
@@ -50,14 +50,8 @@ def _prepare_open_secgroup(endpoint, secgroup_name):
     rules_to_add = [
         {
             "ip_protocol": "tcp",
-            "to_port": 65535,
-            "from_port": 1,
-            "ip_range": {"cidr": "0.0.0.0/0"}
-        },
-        {
-            "ip_protocol": "udp",
-            "to_port": 65535,
-            "from_port": 1,
+            "to_port": 22,
+            "from_port": 22,
             "ip_range": {"cidr": "0.0.0.0/0"}
         },
         {

--- a/samples/tasks/support/README.rst
+++ b/samples/tasks/support/README.rst
@@ -9,3 +9,7 @@ instance_dd_test.sh
 instance_dd_test.sh, will kick off a IO intesnive workload within a OpenStack instance.
 This script will return the write and read performance dd was able to achieve in a
 JSON format.
+
+ping_test.sh
+=============
+ping_test.sh, will ping "www.google.com" five times, confirming that IP connectivity to the instance works, IP connectivity from the instance to the Internet works, name resolution works and SSH key-injection is functional. Keep in mind that the Rally tasks apply a dedicated security group allowing access to all ports (1:65000) to the newly spawned instance(s), then use injected ssh keys to login and execute the ping command. Because of this, it is recommended that the image used by Rally not be Cirros or other image with known credentials (Ubuntu is preferred because it only allows ssh key-based access by default).

--- a/samples/tasks/support/ping_test.sh
+++ b/samples/tasks/support/ping_test.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+ping_res=$(ping -c 5 -q www.google.com | awk -F"," '{print $3}'| sed 's/%//'| grep packet| awk '{print $1}')
+echo "{\"packet_loss\": $ping_res}"


### PR DESCRIPTION
I added a new test that spins a VM and pings from it in order to verify network connectivity and the proper provisioning of the VM. Also, restricted the security group created by Rally to only allow SSH and ICMP.