### PR TITLE
Use testtools' assertions

### DIFF
--- a/rally/task/functional.py
+++ b/rally/task/functional.py
@@ -13,94 +13,17 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
-from rally import exceptions
+import testtools
 
 
-class FunctionalMixin(object):
+class FunctionalMixin(testtools.TestCase):
 
-    def _concatenate_message(self, default, extended):
-        if not extended:
-            return default
-        if default[-1] != ".":
-            default += "."
-        return default + " " + extended.capitalize()
+    # Simulate normal testools run.
+    _testMethodName = "test"
 
-    def assertEqual(self, first, second, err_msg=None):
-        if first != second:
-            msg = "%s != %s" % (repr(first),
-                                repr(second))
-            raise exceptions.RallyAssertionError(
-                self._concatenate_message(msg, err_msg))
-
-    def assertNotEqual(self, first, second, err_msg=None):
-        if first == second:
-            msg = "%s == %s" % (repr(first),
-                                repr(second))
-            raise exceptions.RallyAssertionError(
-                self._concatenate_message(msg, err_msg))
-
-    def assertTrue(self, value, err_msg=None):
-        if not value:
-            msg = "%s is not True" % repr(value)
-            raise exceptions.RallyAssertionError(
-                self._concatenate_message(msg, err_msg))
-
-    def assertFalse(self, value, err_msg=None):
-        if value:
-            msg = "%s is not False" % repr(value)
-            raise exceptions.RallyAssertionError(
-                self._concatenate_message(msg, err_msg))
-
-    def assertIs(self, first, second, err_msg=None):
-        if first is not second:
-            msg = "%s is not %s" % (repr(first),
-                                    repr(second))
-            raise exceptions.RallyAssertionError(
-                self._concatenate_message(msg, err_msg))
-
-    def assertIsNot(self, first, second, err_msg=None):
-        if first is second:
-            msg = "%s is %s" % (repr(first),
-                                repr(second))
-            raise exceptions.RallyAssertionError(
-                self._concatenate_message(msg, err_msg))
-
-    def assertIsNone(self, value, err_msg=None):
-        if value is not None:
-            msg = "%s is not None" % repr(value)
-            raise exceptions.RallyAssertionError(
-                self._concatenate_message(msg, err_msg))
-
-    def assertIsNotNone(self, value, err_msg=None):
-        if value is None:
-            msg = "%s is None" % repr(value)
-            raise exceptions.RallyAssertionError(
-                self._concatenate_message(msg, err_msg))
-
-    def assertIn(self, member, container, err_msg=None):
-        if member not in container:
-            msg = "%s not found in %s" % (repr(member),
-                                          repr(container))
-            raise exceptions.RallyAssertionError(
-                self._concatenate_message(msg, err_msg))
-
-    def assertNotIn(self, member, container, err_msg=None):
-        if member in container:
-            msg = "%s found in %s" % (repr(member),
-                                      repr(container))
-            raise exceptions.RallyAssertionError(
-                self._concatenate_message(msg, err_msg))
-
-    def assertIsInstance(self, first, second, err_msg=None):
-        if not isinstance(first, second):
-            msg = "%s is not instance of %s" % (repr(first),
-                                                repr(second))
-            raise exceptions.RallyAssertionError(
-                self._concatenate_message(msg, err_msg))
-
+    # Backward-compatible `assertIsNotInstance` method.
     def assertIsNotInstance(self, first, second, err_msg=None):
-        if isinstance(first, second):
-            msg = "%s is instance of %s" % (repr(first),
-                                            repr(second))
-            raise exceptions.RallyAssertionError(
-                self._concatenate_message(msg, err_msg))
+        self.assertThat(
+            first,
+            testtools.matchers.Not(testtools.matchers.IsInstance(second)),
+            message=err_msg)

--- a/requirements.txt
+++ b/requirements.txt
@@ -38,6 +38,7 @@ requests>=2.8.1
 SQLAlchemy<1.1.0,>=0.9.9
 sphinx!=1.2.0,!=1.3b1,<1.3,>=1.1.2
 six>=1.9.0
+testtools>=1.4.0
 
 # Python 2.6 related packages(see rally.common.costilius for more details)
 ordereddict

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -8,7 +8,6 @@ ddt>=0.7.0
 mock>=1.2
 python-dateutil>=2.4.2
 testrepository>=0.0.18
-testtools>=1.4.0
 
 oslosphinx!=3.4.0,>=2.5.0 # Apache-2.0
 oslotest>=1.10.0 # Apache-2.0

--- a/tests/unit/task/test_functional.py
+++ b/tests/unit/task/test_functional.py
@@ -13,146 +13,49 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
-import sys
 
-import testtools
+import random
+import uuid
 
-from rally import exceptions
-from rally.task import functional
+from testtools import matchers
+
+from rally.task import scenario
 from tests.unit import test
 
 
 class FunctionalMixinTestCase(test.TestCase):
 
-    def test_asserts(self):
-        class A(functional.FunctionalMixin):
-            def __init__(self):
-                super(A, self).__init__()
+    def test_implements_assertions(self):
+        self.assertThat(
+            dir(scenario.Scenario()),
+            matchers.ContainsAll([
+                "assertEqual",
+                "assertNotEqual",
+                "assertTrue",
+                "assertFalse",
+                "assertIs",
+                "assertIsNot",
+                "assertIsNone",
+                "assertIsNotNone",
+                "assertNotIn",
+                "assertIsInstance",
+                "assertIsNotInstance",
+            ]),
+        )
 
-        a = A()
-        a.assertEqual(1, 1)
-        self.assertRaises(exceptions.RallyAssertionError,
-                          a.assertEqual, "a", "b")
 
-        a.assertNotEqual(1, 2)
-        self.assertRaises(exceptions.RallyAssertionError,
-                          a.assertNotEqual, "a", "a")
+class AssertIsNotInstanceTestCase(test.TestCase):
+    """Tests for `AssertIsNotInstance`."""
 
-        a.assertTrue(True)
-        self.assertRaises(exceptions.RallyAssertionError,
-                          a.assertTrue, False)
+    def test_raises_when_type_matches(self):
+        self.assertRaises(
+            matchers._impl.MismatchError,
+            scenario.Scenario().assertIsNotInstance,
+            random.randint(1, 100),
+            int,
+        )
 
-        a.assertFalse(False)
-        self.assertRaises(exceptions.RallyAssertionError,
-                          a.assertFalse, True)
-
-        a.assertIs("a", "a")
-        self.assertRaises(exceptions.RallyAssertionError,
-                          a.assertIs, "a", "b")
-
-        a.assertIsNot("a", "b")
-        self.assertRaises(exceptions.RallyAssertionError,
-                          a.assertIsNot, "a", "a")
-
-        a.assertIsNone(None)
-        self.assertRaises(exceptions.RallyAssertionError,
-                          a.assertIsNone, "a")
-
-        a.assertIsNotNone("a")
-        self.assertRaises(exceptions.RallyAssertionError,
-                          a.assertIsNotNone, None)
-
-        a.assertIn("1", ["1", "2", "3"])
-        self.assertRaises(exceptions.RallyAssertionError,
-                          a.assertIn, "4", ["1", "2", "3"])
-
-        a.assertNotIn("4", ["1", "2", "3"])
-        self.assertRaises(exceptions.RallyAssertionError,
-                          a.assertNotIn, "1", ["1", "2", "3"])
-
-        a.assertIsInstance("a", str)
-        self.assertRaises(exceptions.RallyAssertionError,
-                          a.assertIsInstance, "a", int)
-
-        a.assertIsNotInstance("a", int)
-        self.assertRaises(exceptions.RallyAssertionError,
-                          a.assertIsNotInstance, "a", str)
-
-    @testtools.skipIf(sys.version_info < (2, 7),
-                      "assertRaises as context not supported")
-    def test_assert_with_custom_message(self):
-        class A(functional.FunctionalMixin):
-            def __init__(self):
-                super(A, self).__init__()
-
-        a = A()
-        custom_message = "A custom message"
-        assert_message = "Assertion error: .+\\. " + custom_message
-
-        a.assertEqual(1, 1, "It's equal")
-        message = self._catch_exception_message(a.assertEqual,
-                                                "a", "b", custom_message)
-        self.assertRegex(message, assert_message)
-
-        a.assertNotEqual(1, 2)
-        message = self._catch_exception_message(a.assertNotEqual,
-                                                "a", "a", custom_message)
-        self.assertRegex(message, assert_message)
-
-        a.assertTrue(True)
-        message = self._catch_exception_message(a.assertTrue,
-                                                False, custom_message)
-        self.assertRegex(message, assert_message)
-
-        a.assertFalse(False)
-        message = self._catch_exception_message(a.assertFalse,
-                                                True, custom_message)
-        self.assertRegex(message, assert_message)
-
-        a.assertIs("a", "a")
-        message = self._catch_exception_message(a.assertIs,
-                                                "a", 1, custom_message)
-        self.assertRegex(message, assert_message)
-
-        a.assertIsNot("a", "b")
-        message = self._catch_exception_message(a.assertIsNot,
-                                                "a", "a", custom_message)
-        self.assertRegex(message, assert_message)
-
-        a.assertIsNone(None)
-        message = self._catch_exception_message(a.assertIsNone,
-                                                "a", custom_message)
-        self.assertRegex(message, assert_message)
-
-        a.assertIsNotNone("a")
-        message = self._catch_exception_message(a.assertIsNotNone,
-                                                None, custom_message)
-        self.assertRegex(message, assert_message)
-
-        a.assertIn("1", ["1", "2", "3"])
-        message = self._catch_exception_message(a.assertIn,
-                                                "1", ["2", "3", "4"],
-                                                custom_message)
-        self.assertRegex(message, assert_message)
-
-        a.assertNotIn("4", ["1", "2", "3"])
-        message = self._catch_exception_message(a.assertNotIn,
-                                                "1", ["1", "2", "3"],
-                                                custom_message)
-        self.assertRegex(message, assert_message)
-
-        a.assertIsInstance("a", str)
-        message = self._catch_exception_message(a.assertIsInstance,
-                                                "a", int, custom_message)
-        self.assertRegex(message, assert_message)
-
-        a.assertIsNotInstance("a", int)
-        message = self._catch_exception_message(a.assertIsNotInstance,
-                                                "a", str, custom_message)
-        self.assertRegex(message, assert_message)
-
-    def _catch_exception_message(self, func, *args):
-        try:
-            func(*args)
-        except Exception as e:
-            return str(e)
+    def test_returns_none_when_instance_does_not_matche_type(self):
+        random_str = uuid.uuid4()
+        self.assertIsNone(
+            scenario.Scenario().assertIsNotInstance(random_str, int))


### PR DESCRIPTION
Instead of using custom-defined assertions, have the scenarios derive from testtools' TestCase so that all the testtools' assertion can be used.  Added the definition of one assertion defined here but not present in testools: `assertIsNotInstance`.
The main benefit of this change is that it allows complex assertions to be composed with testtools' matchers and `assertThat` (see http://testtools.readthedocs.org/en/latest/for-test-authors.html#using-matchers for details).