### PR TITLE
Fix scenario miscount in the tutorial

### DIFF
--- a/doc/source/tutorial/step_5_task_templates.rst
+++ b/doc/source/tutorial/step_5_task_templates.rst
@@ -63,7 +63,7 @@ A nice feature of the input task format used in Rally is that it supports the **
               tenants: 1
               users_per_tenant: 1
 
-In all the three scenarios above, the *"^cirros.*uec$"* image is passed to the scenario as an argument (so that these scenarios use an appropriate image while booting servers). Let’s say you want to run the same set of scenarios with the same runner/context/sla, but you want to try another image while booting server to compare the performance. The most elegant solution is then to turn the image name into a template variable:
+In both scenarios above, the *"^cirros.*uec$"* image is passed to the scenario as an argument (so that these scenarios use an appropriate image while booting servers). Let’s say you want to run the same set of scenarios with the same runner/context/sla, but you want to try another image while booting server to compare the performance. The most elegant solution is then to turn the image name into a template variable:
 
 .. code-block:: yaml
 


### PR DESCRIPTION
The example lists two scenarios, but the description text says "In all three scenarios above".

Fix it to "In both scenarios above".